### PR TITLE
Update role points if adding a role which already exists

### DIFF
--- a/cogs/bot_settings.py
+++ b/cogs/bot_settings.py
@@ -43,7 +43,7 @@ settings_menu = vbu.menus.Menu(
         callback=vbu.menus.MenuIterable(
             select_sql="""SELECT * FROM role_list WHERE guild_id=$1 AND key='RoleGain'""",
             select_sql_args=lambda ctx: (ctx.guild.id,),
-            insert_sql="""INSERT INTO role_list (guild_id, role_id, value, key) VALUES ($1, $2, $3, 'RoleGain')""",
+            insert_sql="""INSERT INTO role_list (guild_id, role_id, value, key) VALUES ($1, $2, $3, 'RoleGain') ON CONFLICT (role_id) DO UPDATE SET value = $3""",
             insert_sql_args=lambda ctx, data: (ctx.guild.id, data[0].id, str(data[1])),
             delete_sql="""DELETE FROM role_list WHERE guild_id=$1 AND role_id=$2 AND key='RoleGain'""",
             delete_sql_args=lambda ctx, row: (ctx.guild.id, row['role_id'],),


### PR DESCRIPTION
This *probably* shouldn't be how to handle this, but it's a temporary solution to the problem stated in https://discord.com/channels/208895639164026880/689189589776203861/951929795057438740

Basically, the buttons inside the Role Gain Settings page don't actually do anything, and just return back to the Main settings page. I have no idea how to fix this, but this seems like an okay way to get around not being able to edit roles. 

Unfortunately, we can't delete roles with this approach, so we should actually fix the buttons in the Role Gain Settings page /shrug